### PR TITLE
[BUGFIX] Remove list action from non-cachable actions

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -9,11 +9,8 @@ defined('TYPO3') or die();
             \TalanHdf\SemanticSuggestion\Controller\SuggestionsController::class => 'list'
         ],
         // non-cacheable actions
-        [
-            \TalanHdf\SemanticSuggestion\Controller\SuggestionsController::class => 'list'
-        ]
+        []
     );
-
 
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTypoScriptSetup(
         '<INCLUDE_TYPOSCRIPT: source="FILE:EXT:semantic_suggestion/Configuration/TypoScript/setup.typoscript">'


### PR DESCRIPTION
Il semble y avoir des soucis de perf quand on arrive à un certain nombre d'articles, sujet à creuser. Mais dans un premier temps le plugin doit être mis en cache quoi qu'il arrive. 