### PR TITLE
fix: added missing scheduler dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
         }
     ],
     "require": {
-        "typo3/cms-core": "^12.0 || ^13.0"
+        "typo3/cms-core": "^12.0 || ^13.0",
+        "typo3/cms-scheduler": "^12.0 || ^13.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
when installing the extension, the scheduler core extension is not installed by dependency. you end up with an exception. adding the dependency fixes that.